### PR TITLE
Integrated RMLSA PseudoPartition updated

### DIFF
--- a/src/main/java/grmlsa/integrated/PseudoPartition.java
+++ b/src/main/java/grmlsa/integrated/PseudoPartition.java
@@ -28,10 +28,12 @@ import java.util.List;
  */
 public class PseudoPartition implements IntegratedRMLSAAlgorithmInterface {
 
+
     /**
-     * Larguras de banda que utilizam o espectro de cima para baixo
+     *
+     New circuits will be allocated using @spectrumAssignment1 if their bandwidth requirement is lower than the threshold. Otherwise, they will be allocated using @spectrumAssignment2.
      */
-    private HashSet<Double> largBandSuperiores;
+    private Double threshold;
 
     private NewKShortestPaths kShortestsPaths;
     private ModulationSelectionAlgorithmInterface modulationSelection;
@@ -39,8 +41,7 @@ public class PseudoPartition implements IntegratedRMLSAAlgorithmInterface {
 	private SpectrumAssignmentAlgorithmInterface spectrumAssignment2;
 
     public PseudoPartition() {
-        largBandSuperiores = new HashSet<>();
-        largBandSuperiores.add(343597383680.0); //320Gbps
+        threshold = 300000000000.0; // 300Gbps
     }
 
     @Override
@@ -63,7 +64,7 @@ public class PseudoPartition implements IntegratedRMLSAAlgorithmInterface {
         int chosenBand[] = new int[2];
         
         // Check whether the FirstFit should be applied from the bottom up or from the top down
-        if (!largBandSuperiores.contains(circuit.getRequiredBandwidth())) { // Allocate from bottom to top
+        if (circuit.getRequiredBandwidth()<threshold) { // Allocate from bottom to top
             chosenBand[0] = 9999999;
             chosenBand[1] = 9999999;
 


### PR DESCRIPTION
Now PseudoPartition uses a simple threshold to define witch circuits will be allocated using last fit policy and witch circuits will be allocated using first fit policy.