### PR TITLE
Modifications inserted: Corrected the way to calculate the number of

### DIFF
--- a/src/main/java/grmlsa/modulation/Modulation.java
+++ b/src/main/java/grmlsa/modulation/Modulation.java
@@ -17,12 +17,9 @@ public class Modulation {
     private double SNRthreshold; // dB
     private double SNRthresholdLinear;
 	
-    private double rateFEC; // Forward Error Correction
+    private double rateFEC; // rate of Forward Error Correction
 	private double freqSlot;
 	private int guardBand;
-	
-	private boolean activeQoT;
-
 
 	/**
 	 * Creates a new instance of Modulation
@@ -35,7 +32,7 @@ public class Modulation {
 	 * @param M double
 	 * @param FEC double
 	 */
-    public Modulation(String name, double maxRange, double M, double SNRthreshold, double rateFEC, double freqSlot, int guardBand, boolean activeQoT) {
+    public Modulation(String name, double maxRange, double M, double SNRthreshold, double rateFEC, double freqSlot, int guardBand) {
         this.name = name;
         this.maxRange = maxRange;
         this.M = M;
@@ -47,7 +44,6 @@ public class Modulation {
         // Calculation based on article: Capacity Limits of Optical Fiber Networks (2010)
         this.bitsPerSymbol = PhysicalLayer.log2(M);
         this.SNRthresholdLinear = PhysicalLayer.ratioOfDB(SNRthreshold);
-        this.activeQoT = activeQoT;
     }
 
     /**
@@ -62,20 +58,16 @@ public class Modulation {
      * @return int - numberOfStos
      */
     public int requiredSlots(double bandwidth) {
-        double numberOfSlots = bandwidth / (bitsPerSymbol * freqSlot);
+    	double slotsNumber = (bandwidth * (1.0 + rateFEC)) / (bitsPerSymbol * freqSlot);
         
-        if(activeQoT){
-        	numberOfSlots = (1.1 * bandwidth * (1.0 + rateFEC)) / (2.0 * bitsPerSymbol * freqSlot);
-        }
-        
-        int numberOfSlotsTemp = (int) numberOfSlots;
-        if (numberOfSlots - numberOfSlotsTemp != 0.0) {
-            numberOfSlotsTemp++;
+        int slotsNumberTemp = (int) slotsNumber;
+        if (slotsNumber - slotsNumberTemp != 0.0) {
+        	slotsNumberTemp++;
         }
 
-        numberOfSlotsTemp = numberOfSlotsTemp + guardBand; // Adds another slot needed to be used as a guard band
+        slotsNumberTemp = slotsNumberTemp + guardBand; // Adds another slot needed to be used as a guard band
 
-        return numberOfSlotsTemp;
+        return slotsNumberTemp;
     }
 
     /**
@@ -84,13 +76,9 @@ public class Modulation {
      * @return
      */
     public double potentialBandwidth(int slotsNumber){
-        slotsNumber--; //remove the slot needed to be used as a guard band
-
-        if(activeQoT){
-            return slotsNumber * 2 * bitsPerSymbol * freqSlot / ((1+rateFEC)*1.1);
-        }else {
-            return slotsNumber * bitsPerSymbol * freqSlot;
-        }
+    	slotsNumber = slotsNumber - guardBand; // Remove the slot needed to be used as a guard band
+        
+        return (slotsNumber * bitsPerSymbol * freqSlot) / (1.0 + rateFEC);
     }
     
 	/**
@@ -145,5 +133,14 @@ public class Modulation {
      */
     public double getSNRthresholdLinear(){
     	return SNRthresholdLinear;
+    }
+    
+    /**
+     * Returns the guard band
+     * 
+     * @return int
+     */
+    public int getGuardBand(){
+    	return guardBand;
     }
 }

--- a/src/main/java/grmlsa/modulation/ModulationSelector.java
+++ b/src/main/java/grmlsa/modulation/ModulationSelector.java
@@ -30,16 +30,15 @@ public class ModulationSelector {
 		double freqSlot = mesh.getLinkList().get(0).getSlotSpectrumBand();
 		double rateFEC = mesh.getPhysicalLayer().getRateOfFEC();
 		int guardBand = mesh.getGuardBand();
-		boolean activeQoT = mesh.getPhysicalLayer().isActiveQoT();
 		
 		List<Modulation> avaliableModulations = new ArrayList<>();
 		// String name, double maxRange, double M, double SNRthreshold, double rateFEC, double freqSlot, int guardBand, boolean activeQoT
-		avaliableModulations.add(new Modulation("BPSK", 10000.0, 2.0, 5.5, rateFEC, freqSlot, guardBand, activeQoT));
-		avaliableModulations.add(new Modulation("QPSK", 5000.0, 4.0, 8.5, rateFEC, freqSlot, guardBand, activeQoT));
-		avaliableModulations.add(new Modulation("8QAM", 2500.0, 8.0, 12.5, rateFEC, freqSlot, guardBand, activeQoT));
-		avaliableModulations.add(new Modulation("16QAM", 1250.0, 16.0, 15.1, rateFEC, freqSlot, guardBand, activeQoT));
-		avaliableModulations.add(new Modulation("32QAM", 625.0, 32.0, 18.1, rateFEC, freqSlot, guardBand, activeQoT));
-		avaliableModulations.add(new Modulation("64QAM", 312.0, 64.0, 21.0, rateFEC, freqSlot, guardBand, activeQoT));
+		avaliableModulations.add(new Modulation("BPSK", 10000.0, 2.0, 5.5, rateFEC, freqSlot, guardBand));
+		avaliableModulations.add(new Modulation("QPSK", 5000.0, 4.0, 8.5, rateFEC, freqSlot, guardBand));
+		avaliableModulations.add(new Modulation("8QAM", 2500.0, 8.0, 12.5, rateFEC, freqSlot, guardBand));
+		avaliableModulations.add(new Modulation("16QAM", 1250.0, 16.0, 15.1, rateFEC, freqSlot, guardBand));
+		avaliableModulations.add(new Modulation("32QAM", 625.0, 32.0, 18.1, rateFEC, freqSlot, guardBand));
+		avaliableModulations.add(new Modulation("64QAM", 312.0, 64.0, 21.0, rateFEC, freqSlot, guardBand));
 		
 		return avaliableModulations;
 	}

--- a/src/main/java/network/Spectrum.java
+++ b/src/main/java/network/Spectrum.java
@@ -116,7 +116,6 @@ public class Spectrum {
 				throw new Exception("spectrum is already free. spectrum band: " + spectrumBand[0] + " - " + spectrumBand[1]);
 			}
 		}
-
 		
 		this.freeSpectrumBands.add(spectrumBand); //liberando spectro
 

--- a/src/main/java/network/TranslucentControlPlane.java
+++ b/src/main/java/network/TranslucentControlPlane.java
@@ -111,7 +111,7 @@ public class TranslucentControlPlane extends ControlPlane {
      * @return boolean - True, if QoT is acceptable, or false, otherwise
      */
 	@Override
-	protected boolean computeQualityOfTransmission(Circuit circuit){
+	public boolean computeQualityOfTransmission(Circuit circuit){
     	boolean minQoT = true;
 		int sourceNodeIndex = 0;
 		double minSNRdB = Double.MAX_VALUE;
@@ -529,7 +529,9 @@ public class TranslucentControlPlane extends ControlPlane {
 				}
 
 				// Now you can check the QoT by transparent segment
-				return !computeQualityOfTransmission(circuit);
+				if(!computeQualityOfTransmission(circuit)){
+					return true;
+				}
 			}
 		}
 		

--- a/src/main/java/simulationControl/parsers/PhysicalLayerConfig.java
+++ b/src/main/java/simulationControl/parsers/PhysicalLayerConfig.java
@@ -31,6 +31,8 @@ public class PhysicalLayerConfig {
 	private double noiseFactorModelParameterA2; // A2, Amplifier noise factor parameter
 	private double opticalNoiseBandwidth; // B0, Optical bandwidth, it has a value of 1 because we are considering SNR
 	
+	private double switchInsertionLoss; // dB
+	
 	/**
 	 * @return the activeQoT
 	 */
@@ -249,5 +251,16 @@ public class PhysicalLayerConfig {
 	public void setOpticalNoiseBandwidth(double opticalNoiseBandwidth) {
 		this.opticalNoiseBandwidth = opticalNoiseBandwidth;
 	}
-	
+	/**
+	 * @return the switchInsertionLoss
+	 */
+	public double getSwitchInsertionLoss() {
+		return switchInsertionLoss;
+	}
+	/**
+	 * @param switchInsertionLoss the switchInsertionLoss to set
+	 */
+	public void setSwitchInsertionLoss(double switchInsertionLoss) {
+		this.switchInsertionLoss = switchInsertionLoss;
+	}
 }


### PR DESCRIPTION
Modifications inserted:
- Corrected the bug of the lack of influence of the amount of band guard slots in the physical layer. Before, the amount of band guard slots was fixed to the physical layer;
- Corrected the way to calculate the number of slots without and with the physical layer;
- Inserted the accounting of pre and post-amplifiers in the physical layer;
- Just check the account blocking checks by QoTN and QoTO in the Control Plane;
- Inserted the input value of the switch insertion loss into the physical layer file;