### PR TITLE
Refactoring spectrum utilization and physical layer.

### DIFF
--- a/src/main/java/measurement/SpectrumUtilization.java
+++ b/src/main/java/measurement/SpectrumUtilization.java
@@ -22,8 +22,8 @@ public class SpectrumUtilization extends Measurement {
     private double utilizationGen;
     private int numberObservations;
     private HashMap<String, Double> utilizationPerLink;
-
     private int[] desUtilizationPerSlot;
+    private Integer maxSlotsByLinks;
 
     /**
      * Creates a new instance of SpectrumUtilization
@@ -39,7 +39,7 @@ public class SpectrumUtilization extends Measurement {
         numberObservations = 0;
         utilizationPerLink = new HashMap<String, Double>();
 
-        int maxSlotsByLinks = mesh.maximumSlotsByLinks();
+        maxSlotsByLinks = mesh.maximumSlotsByLinks();
         desUtilizationPerSlot = new int[maxSlotsByLinks];
         
         fileName = "_SpectrumUtilization.csv";
@@ -143,4 +143,12 @@ public class SpectrumUtilization extends Measurement {
         return 1 - desUt;
     }
 
+    /**
+     * Returns the maximum slots by links
+     * 
+     * @return int
+     */
+    public int getMaxSlotsByLinks(){
+    	return maxSlotsByLinks;
+    }
 }

--- a/src/main/java/network/Mesh.java
+++ b/src/main/java/network/Mesh.java
@@ -80,7 +80,7 @@ public class Mesh implements Serializable {
         }
         
         // Information related to the physical layer of the network
-        this.physicalLayer = new PhysicalLayer(plc);
+        this.physicalLayer = new PhysicalLayer(plc, this);
     }
 
     /**

--- a/src/main/java/simulationControl/resultManagers/SpectrumUtilizationResultManager.java
+++ b/src/main/java/simulationControl/resultManagers/SpectrumUtilizationResultManager.java
@@ -18,6 +18,7 @@ public class SpectrumUtilizationResultManager implements ResultManagerInterface 
 	private List<Integer> loadPoints;
 	private List<Integer> replications;
 	private final static String sep = ",";
+	private Integer slotsNumber;
 	
 	/**
 	 * This method organizes the data by load point and replication.
@@ -34,6 +35,10 @@ public class SpectrumUtilizationResultManager implements ResultManagerInterface 
 			
 			for (Measurement su : loadPoint) {
 				reps.put(su.getReplication(), (SpectrumUtilization)su);
+				
+				if(slotsNumber == null){
+					slotsNumber = ((SpectrumUtilization)su).getMaxSlotsByLinks();
+				}
 			}			
 		}
 		loadPoints = new ArrayList<>(sus.keySet());
@@ -116,8 +121,7 @@ public class SpectrumUtilizationResultManager implements ResultManagerInterface 
 		StringBuilder res = new StringBuilder();
 		for (Integer loadPoint : loadPoints) {
 			String aux = "Utilization Per Slot" + sep + loadPoint + sep + "all" + sep + " - " + sep;
-			int i;
-			for(i=1;i<=400;i++){
+			for(int i = 1; i <= slotsNumber; i++){
 				String aux2 = aux + i + sep + " ";
 				for (Integer rep : replications) {
 					aux2 = aux2 + sep + sus.get(loadPoint).get(rep).getUtilizationPerSlot(i);


### PR DESCRIPTION
Removing the limitation of the calculation of the use of spectrum of 400 slots per link and calculating the value according to the one informed in the configuration file of the network.
Removed the calculation of the lowest spectrum frequency of a method and placed it in the constructor of the PhysicalLayer class.